### PR TITLE
Fix typo in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,7 +129,7 @@ If you choosed to use WSL's ssh client in the above section, we need to make ssh
 
 #### 3. Windows's ssh-agent
 
-If we use ssh.exe, we shoule make ssh-agent work in Windows:
+If we use ssh.exe, we should make ssh-agent work in Windows:
 - Use Windows OpenSSH agent by enabling `OpenSSH Authentication Agent` service
 - Or use password manager's ssh-agent, like Bitwarden, KeePassXC or 1Password
 


### PR DESCRIPTION
## Summary
- fix a typo in instructions for using ssh-agent

## Testing
- `grep -n should readme.md`

------
https://chatgpt.com/codex/tasks/task_e_68754f5b9c90832f90243ab65ebed9bd